### PR TITLE
Fix to #2403 - Have a way to turn off null semantics at the context l…

### DIFF
--- a/src/EntityFramework.Core/Query/ExpressionVisitors/ParameterExtractingExpressionVisitor.cs
+++ b/src/EntityFramework.Core/Query/ExpressionVisitors/ParameterExtractingExpressionVisitor.cs
@@ -5,10 +5,10 @@ using System;
 using System.Collections;
 using System.Linq;
 using System.Linq.Expressions;
+using System.Reflection;
 using JetBrains.Annotations;
 using Microsoft.Data.Entity.Internal;
 using Remotion.Linq.Parsing.ExpressionVisitors.TreeEvaluation;
-using System.Reflection;
 
 namespace Microsoft.Data.Entity.Query.ExpressionVisitors
 {

--- a/src/EntityFramework.Core/Query/ICompiledQueryCacheKeyGenerator.cs
+++ b/src/EntityFramework.Core/Query/ICompiledQueryCacheKeyGenerator.cs
@@ -3,11 +3,12 @@
 
 using System.Linq.Expressions;
 using JetBrains.Annotations;
+using Microsoft.Data.Entity.Storage;
 
 namespace Microsoft.Data.Entity.Query
 {
     public interface ICompiledQueryCacheKeyGenerator
     {
-        object GenerateCacheKey([NotNull] Expression query, bool async);
+        object GenerateCacheKey([NotNull] Expression query, [NotNull] IDatabase database, bool async);
     }
 }

--- a/src/EntityFramework.Core/Query/IEntityQueryModelVisitorFactory.cs
+++ b/src/EntityFramework.Core/Query/IEntityQueryModelVisitorFactory.cs
@@ -2,15 +2,17 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using JetBrains.Annotations;
+using Microsoft.Data.Entity.Storage;
 
 namespace Microsoft.Data.Entity.Query
 {
     public interface IEntityQueryModelVisitorFactory
     {
-        EntityQueryModelVisitor Create([NotNull] QueryCompilationContext queryCompilationContext);
+        EntityQueryModelVisitor Create([NotNull] QueryCompilationContext queryCompilationContext, [NotNull] IDatabase database);
 
         EntityQueryModelVisitor Create(
             [NotNull] QueryCompilationContext queryCompilationContext,
+            [NotNull] IDatabase database,
             [CanBeNull] EntityQueryModelVisitor parentEntityQueryModelVisitor);
     }
 }

--- a/src/EntityFramework.Core/Query/IQueryCompilationContextFactory.cs
+++ b/src/EntityFramework.Core/Query/IQueryCompilationContextFactory.cs
@@ -1,10 +1,13 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using JetBrains.Annotations;
+using Microsoft.Data.Entity.Storage;
+
 namespace Microsoft.Data.Entity.Query
 {
     public interface IQueryCompilationContextFactory
     {
-        QueryCompilationContext Create(bool async);
+        QueryCompilationContext Create([NotNull] IDatabase database, bool async);
     }
 }

--- a/src/EntityFramework.Core/Query/QueryCompilationContext.cs
+++ b/src/EntityFramework.Core/Query/QueryCompilationContext.cs
@@ -24,21 +24,25 @@ namespace Microsoft.Data.Entity.Query
         private IReadOnlyCollection<QueryAnnotationBase> _queryAnnotations;
         private IDictionary<IQuerySource, List<IReadOnlyList<INavigation>>> _trackableIncludes;
         private ISet<IQuerySource> _querySourcesRequiringMaterialization;
+        private IDatabase _database;
 
         public QueryCompilationContext(
             [NotNull] ILoggerFactory loggerFactory,
             [NotNull] IEntityQueryModelVisitorFactory entityQueryModelVisitorFactory,
             [NotNull] IRequiresMaterializationExpressionVisitorFactory requiresMaterializationExpressionVisitorFactory,
+            [NotNull] IDatabase database,
             [NotNull] ILinqOperatorProvider linqOperatorProvider)
         {
             Check.NotNull(loggerFactory, nameof(loggerFactory));
             Check.NotNull(entityQueryModelVisitorFactory, nameof(entityQueryModelVisitorFactory));
             Check.NotNull(requiresMaterializationExpressionVisitorFactory, nameof(requiresMaterializationExpressionVisitorFactory));
+            Check.NotNull(database, nameof(database));
             Check.NotNull(linqOperatorProvider, nameof(linqOperatorProvider));
 
             Logger = loggerFactory.CreateLogger<Database>();
             _entityQueryModelVisitorFactory = entityQueryModelVisitorFactory;
             _requiresMaterializationExpressionVisitorFactory = requiresMaterializationExpressionVisitorFactory;
+            _database = database;
             LinqOperatorProvider = linqOperatorProvider;
         }
 
@@ -66,10 +70,10 @@ namespace Microsoft.Data.Entity.Query
                 .Where(qa => qa.IsCallTo(Check.NotNull(methodInfo, nameof(methodInfo))));
 
         public virtual EntityQueryModelVisitor CreateQueryModelVisitor()
-            => _entityQueryModelVisitorFactory.Create(this);
+            => _entityQueryModelVisitorFactory.Create(this, _database);
 
         public virtual EntityQueryModelVisitor CreateQueryModelVisitor([CanBeNull] EntityQueryModelVisitor parentEntityQueryModelVisitor)
-            => _entityQueryModelVisitorFactory.Create(parentEntityQueryModelVisitor.QueryCompilationContext, parentEntityQueryModelVisitor);
+            => _entityQueryModelVisitorFactory.Create(parentEntityQueryModelVisitor.QueryCompilationContext, _database, parentEntityQueryModelVisitor);
 
         public virtual void AddTrackableInclude(
             [NotNull] IQuerySource querySource, [NotNull] IReadOnlyList<INavigation> navigationPath)

--- a/src/EntityFramework.Core/Query/QueryCompilationContextFactory.cs
+++ b/src/EntityFramework.Core/Query/QueryCompilationContextFactory.cs
@@ -3,6 +3,7 @@
 
 using JetBrains.Annotations;
 using Microsoft.Data.Entity.Query.ExpressionVisitors;
+using Microsoft.Data.Entity.Storage;
 using Microsoft.Data.Entity.Utilities;
 using Microsoft.Framework.Logging;
 
@@ -28,17 +29,19 @@ namespace Microsoft.Data.Entity.Query
             _requiresMaterializationExpressionVisitorFactory = requiresMaterializationExpressionVisitorFactory;
         }
 
-        public virtual QueryCompilationContext Create(bool async)
+        public virtual QueryCompilationContext Create([NotNull] IDatabase database, bool async)
             => async
                 ? new QueryCompilationContext(
                     _loggerFactory,
                     _entityQueryModelVisitorFactory,
                     _requiresMaterializationExpressionVisitorFactory,
+                    Check.NotNull(database, nameof(database)),
                     new AsyncLinqOperatorProvider())
                 : new QueryCompilationContext(
                     _loggerFactory,
                     _entityQueryModelVisitorFactory,
                     _requiresMaterializationExpressionVisitorFactory,
+                    Check.NotNull(database, nameof(database)),
                     new LinqOperatorProvider());
     }
 }

--- a/src/EntityFramework.Core/Query/QueryCompiler.cs
+++ b/src/EntityFramework.Core/Query/QueryCompiler.cs
@@ -53,6 +53,8 @@ namespace Microsoft.Data.Entity.Query
             _database = database;
         }
 
+        protected virtual IDatabase Database => _database;
+
         public virtual TResult Execute<TResult>(Expression query)
         {
             Check.NotNull(query, nameof(query));
@@ -99,12 +101,12 @@ namespace Microsoft.Data.Entity.Query
             return ParameterExtractingExpressionVisitor
                 .ExtractParameters(query, queryContext, _evaluatableExpressionFilter);
         }
-
+        
         protected virtual Func<QueryContext, TResult> CompileQuery<TResult>([NotNull] Expression query)
         {
             Check.NotNull(query, nameof(query));
 
-            return _cache.GetOrAddQuery(_cacheKeyGenerator.GenerateCacheKey(query, async: false), () =>
+            return _cache.GetOrAddQuery(_cacheKeyGenerator.GenerateCacheKey(query, _database, async: false), () =>
                 {
                     var queryModel = CreateQueryParser().GetParsedQuery(query);
 
@@ -137,7 +139,7 @@ namespace Microsoft.Data.Entity.Query
         {
             Check.NotNull(query, nameof(query));
 
-            return _cache.GetOrAddAsyncQuery(_cacheKeyGenerator.GenerateCacheKey(query, async: true), () =>
+            return _cache.GetOrAddAsyncQuery(_cacheKeyGenerator.GenerateCacheKey(query, _database, async: true), () =>
                 {
                     var queryModel = CreateQueryParser().GetParsedQuery(query);
 

--- a/src/EntityFramework.Core/Storage/Database.cs
+++ b/src/EntityFramework.Core/Storage/Database.cs
@@ -31,13 +31,13 @@ namespace Microsoft.Data.Entity.Storage
             CancellationToken cancellationToken = default(CancellationToken));
 
         public virtual Func<QueryContext, IEnumerable<TResult>> CompileQuery<TResult>(QueryModel queryModel)
-            => _compilationContextFactory.Create(async: false)
+            => _compilationContextFactory.Create(this, async: false)
                 .CreateQueryModelVisitor()
                 .CreateQueryExecutor<TResult>(
                     Check.NotNull(queryModel, nameof(queryModel)));
 
         public virtual Func<QueryContext, IAsyncEnumerable<TResult>> CompileAsyncQuery<TResult>(QueryModel queryModel)
-            => _compilationContextFactory.Create(async: true)
+            => _compilationContextFactory.Create(this, async: true)
                 .CreateQueryModelVisitor()
                 .CreateAsyncQueryExecutor<TResult>(
                     Check.NotNull(queryModel, nameof(queryModel)));

--- a/src/EntityFramework.InMemory/Query/InMemoryQueryModelVisitorFactory.cs
+++ b/src/EntityFramework.InMemory/Query/InMemoryQueryModelVisitorFactory.cs
@@ -6,6 +6,7 @@ using Microsoft.Data.Entity.Metadata;
 using Microsoft.Data.Entity.Metadata.Internal;
 using Microsoft.Data.Entity.Query.ExpressionVisitors;
 using Microsoft.Data.Entity.Query.Internal;
+using Microsoft.Data.Entity.Storage;
 using Microsoft.Data.Entity.Utilities;
 
 namespace Microsoft.Data.Entity.Query
@@ -82,11 +83,12 @@ namespace Microsoft.Data.Entity.Query
             _materializerFactory = materializerFactory;
         }
 
-        public virtual EntityQueryModelVisitor Create([NotNull] QueryCompilationContext queryCompilationContext)
-            => Create(queryCompilationContext, null);
+        public virtual EntityQueryModelVisitor Create([NotNull] QueryCompilationContext queryCompilationContext, [NotNull] IDatabase database)
+            => Create(queryCompilationContext, database, null);
 
         public virtual EntityQueryModelVisitor Create(
             [NotNull] QueryCompilationContext queryCompilationContext,
+            [NotNull] IDatabase database,
             [CanBeNull] EntityQueryModelVisitor parentEntityQueryModelVisitor)
             => new InMemoryQueryModelVisitor(
                 _model,

--- a/src/EntityFramework.Relational/EntityFramework.Relational.csproj
+++ b/src/EntityFramework.Relational/EntityFramework.Relational.csproj
@@ -115,6 +115,7 @@
     <Compile Include="Query\ExpressionTranslators\StartsWithTranslator.cs" />
     <Compile Include="Query\ExpressionTranslators\StringCompareTranslator.cs" />
     <Compile Include="Query\Internal\RelationalExpressionPrinter.cs" />
+    <Compile Include="Query\RelationalCompiledQueryCacheKeyGenerator.cs" />
     <Compile Include="Query\RelationalQueryModelVisitorFactory.cs" />
     <Compile Include="Query\RelationalQueryCompilationContextFactory.cs" />
     <Compile Include="Query\Sql\ISqlQueryGeneratorFactory.cs" />
@@ -240,10 +241,10 @@
     <Compile Include="Query\Expressions\SumExpression.cs" />
     <Compile Include="Query\Expressions\TableExpressionBase.cs" />
     <Compile Include="Query\ExpressionVisitors\IsNullExpressionBuildingVisitor.cs" />
-    <Compile Include="Query\ExpressionVisitors\NullSemanticsExpressionVisitorBase.cs" />
+    <Compile Include="Query\ExpressionVisitors\RelationalNullsExpressionVisitorBase.cs" />
     <Compile Include="Query\ExpressionVisitors\PredicateNegationExpressionOptimizer.cs" />
-    <Compile Include="Query\ExpressionVisitors\NullSemanticsExpandingVisitor.cs" />
-    <Compile Include="Query\ExpressionVisitors\NullSemanticsOptimizedExpandingVisitor.cs" />
+    <Compile Include="Query\ExpressionVisitors\RelationalNullsExpandingVisitor.cs" />
+    <Compile Include="Query\ExpressionVisitors\RelationalNullsOptimizedExpandingVisitor.cs" />
     <Compile Include="Query\ExpressionVisitors\SqlTranslatingExpressionVisitor.cs" />
     <Compile Include="Query\AsyncIncludeCollectionIterator.cs" />
     <Compile Include="Query\ExpressionVisitors\IncludeExpressionVisitor.cs" />

--- a/src/EntityFramework.Relational/Infrastructure/RelationalEntityFrameworkServicesBuilderExtensions.cs
+++ b/src/EntityFramework.Relational/Infrastructure/RelationalEntityFrameworkServicesBuilderExtensions.cs
@@ -89,6 +89,7 @@ namespace Microsoft.Data.Entity.Infrastructure
                 .AddScoped<RelationalEntityQueryableExpressionVisitorFactory>()
                 .AddScoped<RelationalQueryModelVisitorFactory>()
                 .AddScoped<RelationalProjectionExpressionVisitorFactory>()
+                .AddScoped<RelationalCompiledQueryCacheKeyGenerator>()
                 .AddScoped(p => GetProviderServices(p).SqlQueryGeneratorFactory);
         }
 

--- a/src/EntityFramework.Relational/Query/ExpressionVisitors/CompositePredicateExpressionVisitor.cs
+++ b/src/EntityFramework.Relational/Query/ExpressionVisitors/CompositePredicateExpressionVisitor.cs
@@ -10,11 +10,11 @@ namespace Microsoft.Data.Entity.Query.ExpressionVisitors
 {
     public class CompositePredicateExpressionVisitor : RelinqExpressionVisitor
     {
-        private readonly bool _useRelationalNullSemantics;
+        private readonly bool _useRelationalNulls;
 
-        public CompositePredicateExpressionVisitor(bool useRelationalNullSemantics)
+        public CompositePredicateExpressionVisitor(bool useRelationalNulls)
         {
-            _useRelationalNullSemantics = useRelationalNullSemantics;
+            _useRelationalNulls = useRelationalNulls;
         }
 
         public override Expression Visit(
@@ -47,22 +47,22 @@ namespace Microsoft.Data.Entity.Query.ExpressionVisitors
             parameterDectector.Visit(currentExpression);
 
             if (!parameterDectector.ContainsParameters
-                && !_useRelationalNullSemantics)
+                && !_useRelationalNulls)
             {
-                var optimizedNullExpansionVisitor = new NullSemanticsOptimizedExpandingVisitor();
-                var nullSemanticsExpandedOptimized = optimizedNullExpansionVisitor.Visit(currentExpression);
+                var optimizedNullExpansionVisitor = new RelationalNullsOptimizedExpandingVisitor();
+                var relationalNullsExpandedOptimized = optimizedNullExpansionVisitor.Visit(currentExpression);
                 if (optimizedNullExpansionVisitor.OptimizedExpansionPossible)
                 {
-                    currentExpression = nullSemanticsExpandedOptimized;
+                    currentExpression = relationalNullsExpandedOptimized;
                 }
                 else
                 {
-                    currentExpression = new NullSemanticsExpandingVisitor()
+                    currentExpression = new RelationalNullsExpandingVisitor()
                         .Visit(currentExpression);
                 }
             }
 
-            if (_useRelationalNullSemantics)
+            if (_useRelationalNulls)
             {
                 currentExpression = new NotNullableExpression(currentExpression);
             }

--- a/src/EntityFramework.Relational/Query/ExpressionVisitors/CompositePredicateExpressionVisitorFactory.cs
+++ b/src/EntityFramework.Relational/Query/ExpressionVisitors/CompositePredicateExpressionVisitorFactory.cs
@@ -7,7 +7,7 @@ namespace Microsoft.Data.Entity.Query.ExpressionVisitors
 {
     public class CompositePredicateExpressionVisitorFactory : ICompositePredicateExpressionVisitorFactory
     {
-        public virtual ExpressionVisitor Create(bool useRelationalNullSemantics)
-            => new CompositePredicateExpressionVisitor(useRelationalNullSemantics);
+        public virtual ExpressionVisitor Create(bool useRelationalNulls)
+            => new CompositePredicateExpressionVisitor(useRelationalNulls);
     }
 }

--- a/src/EntityFramework.Relational/Query/ExpressionVisitors/ICompositePredicateExpressionVisitorFactory.cs
+++ b/src/EntityFramework.Relational/Query/ExpressionVisitors/ICompositePredicateExpressionVisitorFactory.cs
@@ -7,6 +7,6 @@ namespace Microsoft.Data.Entity.Query.ExpressionVisitors
 {
     public interface ICompositePredicateExpressionVisitorFactory
     {
-        ExpressionVisitor Create(bool useRelationalNullSemantics);
+        ExpressionVisitor Create(bool useRelationalNulls);
     }
 }

--- a/src/EntityFramework.Relational/Query/ExpressionVisitors/RelationalNullsExpandingVisitor.cs
+++ b/src/EntityFramework.Relational/Query/ExpressionVisitors/RelationalNullsExpandingVisitor.cs
@@ -7,7 +7,7 @@ using Microsoft.Data.Entity.Query.Expressions;
 
 namespace Microsoft.Data.Entity.Query.ExpressionVisitors
 {
-    public class NullSemanticsExpandingVisitor : NullSemanticsExpressionVisitorBase
+    public class RelationalNullsExpandingVisitor : RelationalNullsExpressionVisitorBase
     {
         protected override Expression VisitBinary(BinaryExpression expression)
         {

--- a/src/EntityFramework.Relational/Query/ExpressionVisitors/RelationalNullsExpressionVisitorBase.cs
+++ b/src/EntityFramework.Relational/Query/ExpressionVisitors/RelationalNullsExpressionVisitorBase.cs
@@ -8,7 +8,7 @@ using Remotion.Linq.Parsing;
 
 namespace Microsoft.Data.Entity.Query.ExpressionVisitors
 {
-    public abstract class NullSemanticsExpressionVisitorBase : RelinqExpressionVisitor
+    public abstract class RelationalNullsExpressionVisitorBase : RelinqExpressionVisitor
     {
         protected virtual Expression BuildIsNullExpression([NotNull] Expression expression)
         {

--- a/src/EntityFramework.Relational/Query/ExpressionVisitors/RelationalNullsOptimizedExpandingVisitor.cs
+++ b/src/EntityFramework.Relational/Query/ExpressionVisitors/RelationalNullsOptimizedExpandingVisitor.cs
@@ -5,11 +5,11 @@ using System.Linq.Expressions;
 
 namespace Microsoft.Data.Entity.Query.ExpressionVisitors
 {
-    public class NullSemanticsOptimizedExpandingVisitor : NullSemanticsExpressionVisitorBase
+    public class RelationalNullsOptimizedExpandingVisitor : RelationalNullsExpressionVisitorBase
     {
         public virtual bool OptimizedExpansionPossible { get; set; }
 
-        public NullSemanticsOptimizedExpandingVisitor()
+        public RelationalNullsOptimizedExpandingVisitor()
         {
             OptimizedExpansionPossible = true;
         }

--- a/src/EntityFramework.Relational/Query/RelationalCompiledQueryCacheKeyGenerator.cs
+++ b/src/EntityFramework.Relational/Query/RelationalCompiledQueryCacheKeyGenerator.cs
@@ -5,16 +5,16 @@ using System.Linq.Expressions;
 using JetBrains.Annotations;
 using Microsoft.Data.Entity.Metadata;
 using Microsoft.Data.Entity.Query.ExpressionVisitors;
-using Microsoft.Data.Entity.Utilities;
 using Microsoft.Data.Entity.Storage;
+using Microsoft.Data.Entity.Utilities;
 
 namespace Microsoft.Data.Entity.Query
 {
-    public class CompiledQueryCacheKeyGenerator : ICompiledQueryCacheKeyGenerator
+    public class RelationalCompiledQueryCacheKeyGenerator : ICompiledQueryCacheKeyGenerator
     {
         private readonly IModel _model;
 
-        public CompiledQueryCacheKeyGenerator([NotNull] IModel model)
+        public RelationalCompiledQueryCacheKeyGenerator([NotNull] IModel model)
         {
             Check.NotNull(model, nameof(model));
 
@@ -25,19 +25,22 @@ namespace Microsoft.Data.Entity.Query
             => new CompiledQueryCacheKey(
                 new ExpressionStringBuilder().Build(Check.NotNull(query, nameof(query))),
                 _model,
-                async);
+                async,
+                ((RelationalDatabase)database).UseRelationalNulls);
 
         private struct CompiledQueryCacheKey
         {
             private readonly string _query;
             private readonly IModel _model;
             private readonly bool _async;
+            private readonly bool _useRelationalNulls;
 
-            public CompiledQueryCacheKey(string query, IModel model, bool async)
+            public CompiledQueryCacheKey(string query, IModel model, bool async, bool useRelationalNulls)
             {
                 _query = query;
                 _model = model;
                 _async = async;
+                _useRelationalNulls = useRelationalNulls;
             }
 
             public override bool Equals(object obj)
@@ -47,7 +50,8 @@ namespace Microsoft.Data.Entity.Query
             private bool Equals(CompiledQueryCacheKey other)
                 => string.Equals(_query, other._query)
                    && _model.Equals(other._model)
-                   && _async == other._async;
+                   && _async == other._async
+                   && _useRelationalNulls == other._useRelationalNulls;
 
             public override int GetHashCode()
             {
@@ -56,6 +60,8 @@ namespace Microsoft.Data.Entity.Query
                     var hashCode = _query.GetHashCode();
                     hashCode = (hashCode * 397) ^ _model.GetHashCode();
                     hashCode = (hashCode * 397) ^ _async.GetHashCode();
+                    hashCode = (hashCode * 397) ^ _useRelationalNulls.GetHashCode();
+
                     return hashCode;
                 }
             }

--- a/src/EntityFramework.Relational/Query/RelationalQueryCompilationContext.cs
+++ b/src/EntityFramework.Relational/Query/RelationalQueryCompilationContext.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using JetBrains.Annotations;
 using Microsoft.Data.Entity.Query.Expressions;
 using Microsoft.Data.Entity.Query.ExpressionVisitors;
+using Microsoft.Data.Entity.Storage;
 using Microsoft.Data.Entity.Utilities;
 using Microsoft.Framework.Logging;
 using Remotion.Linq.Clauses;
@@ -21,12 +22,14 @@ namespace Microsoft.Data.Entity.Query
             [NotNull] ILoggerFactory loggerFactory,
             [NotNull] IEntityQueryModelVisitorFactory entityQueryModelVisitorFactory,
             [NotNull] IRequiresMaterializationExpressionVisitorFactory requiresMaterializationExpressionVisitorFactory,
+            [NotNull] IDatabase database,
             [NotNull] ILinqOperatorProvider linqOperatorProvider,
             [NotNull] IQueryMethodProvider queryMethodProvider)
             : base(
                 Check.NotNull(loggerFactory, nameof(loggerFactory)),
                 Check.NotNull(entityQueryModelVisitorFactory, nameof(entityQueryModelVisitorFactory)),
                 Check.NotNull(requiresMaterializationExpressionVisitorFactory, nameof(requiresMaterializationExpressionVisitorFactory)),
+                Check.NotNull(database, nameof(database)),
                 Check.NotNull(linqOperatorProvider, nameof(linqOperatorProvider)))
         {
             Check.NotNull(queryMethodProvider, nameof(queryMethodProvider));

--- a/src/EntityFramework.Relational/Query/RelationalQueryCompilationContextFactory.cs
+++ b/src/EntityFramework.Relational/Query/RelationalQueryCompilationContextFactory.cs
@@ -3,6 +3,7 @@
 
 using JetBrains.Annotations;
 using Microsoft.Data.Entity.Query.ExpressionVisitors;
+using Microsoft.Data.Entity.Storage;
 using Microsoft.Data.Entity.Utilities;
 using Microsoft.Framework.Logging;
 
@@ -28,18 +29,20 @@ namespace Microsoft.Data.Entity.Query
             _requiresMaterializationExpressionVisitorFactory = requiresMaterializationExpressionVisitorFactory;
         }
 
-        public virtual QueryCompilationContext Create(bool async)
+        public virtual QueryCompilationContext Create(IDatabase database, bool async)
             => async
                 ? new RelationalQueryCompilationContext(
                     _loggerFactory,
                     _entityQueryModelVisitorFactory,
                     _requiresMaterializationExpressionVisitorFactory,
+                    database,
                     new AsyncLinqOperatorProvider(),
                     new AsyncQueryMethodProvider())
                 : new RelationalQueryCompilationContext(
                     _loggerFactory,
                     _entityQueryModelVisitorFactory,
                     _requiresMaterializationExpressionVisitorFactory,
+                    database,
                     new LinqOperatorProvider(),
                     new QueryMethodProvider());
     }

--- a/src/EntityFramework.Relational/Query/RelationalQueryModelVisitorFactory.cs
+++ b/src/EntityFramework.Relational/Query/RelationalQueryModelVisitorFactory.cs
@@ -6,6 +6,7 @@ using Microsoft.Data.Entity.Metadata;
 using Microsoft.Data.Entity.Metadata.Internal;
 using Microsoft.Data.Entity.Query.ExpressionVisitors;
 using Microsoft.Data.Entity.Query.Internal;
+using Microsoft.Data.Entity.Storage;
 using Microsoft.Data.Entity.Utilities;
 
 namespace Microsoft.Data.Entity.Query
@@ -102,11 +103,12 @@ namespace Microsoft.Data.Entity.Query
             _shapedQueryFindingExpressionVisitorFactory = shapedQueryFindingExpressionVisitorFactory;
         }
 
-        public virtual EntityQueryModelVisitor Create([NotNull] QueryCompilationContext queryCompilationContext)
-            => Create(queryCompilationContext, null);
+        public virtual EntityQueryModelVisitor Create([NotNull] QueryCompilationContext queryCompilationContext, IDatabase database)
+            => Create(queryCompilationContext, database, null);
 
         public virtual EntityQueryModelVisitor Create(
             [NotNull] QueryCompilationContext queryCompilationContext,
+            [NotNull] IDatabase database,
             [CanBeNull] EntityQueryModelVisitor parentEntityQueryModelVisitor)
             =>
             new RelationalQueryModelVisitor(
@@ -132,6 +134,7 @@ namespace Microsoft.Data.Entity.Query
                 _queryFlatteningExpressionVisitorFactory,
                 _shapedQueryFindingExpressionVisitorFactory,
                 (RelationalQueryCompilationContext)Check.NotNull(queryCompilationContext, nameof(queryCompilationContext)),
+                database,
                 (RelationalQueryModelVisitor)parentEntityQueryModelVisitor);
     }
 }

--- a/src/EntityFramework.Relational/Query/Sql/DefaultQuerySqlGenerator.cs
+++ b/src/EntityFramework.Relational/Query/Sql/DefaultQuerySqlGenerator.cs
@@ -154,15 +154,15 @@ namespace Microsoft.Data.Entity.Query.Sql
                     // we have to optimize out comparisons to null-valued parameters before we can expand null semantics 
                     if (_parameterValues.Count > 0)
                     {
-                        var optimizedNullExpansionVisitor = new NullSemanticsOptimizedExpandingVisitor();
-                        var nullSemanticsExpandedOptimized = optimizedNullExpansionVisitor.Visit(predicate);
+                        var optimizedNullExpansionVisitor = new RelationalNullsOptimizedExpandingVisitor();
+                        var relationalNullsExpandedOptimized = optimizedNullExpansionVisitor.Visit(predicate);
                         if (optimizedNullExpansionVisitor.OptimizedExpansionPossible)
                         {
-                            predicate = nullSemanticsExpandedOptimized;
+                            predicate = relationalNullsExpandedOptimized;
                         }
                         else
                         {
-                            predicate = new NullSemanticsExpandingVisitor()
+                            predicate = new RelationalNullsExpandingVisitor()
                                 .Visit(predicate);
                         }
                     }
@@ -394,11 +394,11 @@ namespace Microsoft.Data.Entity.Query.Sql
 
                 if (inValues.Count != inValuesNotNull.Count)
                 {
-                    var nullSemanticsInExpression = Expression.OrElse(
+                    var relatioalNullsInExpression = Expression.OrElse(
                         new InExpression(inExpression.Operand, inValuesNotNull),
                         new IsNullExpression(inExpression.Operand));
 
-                    return Visit(nullSemanticsInExpression);
+                    return Visit(relatioalNullsInExpression);
                 }
 
                 if (inValuesNotNull.Count > 0)
@@ -437,11 +437,11 @@ namespace Microsoft.Data.Entity.Query.Sql
 
                 if (inValues.Count != inValuesNotNull.Count)
                 {
-                    var nullSemanticsNotInExpression = Expression.AndAlso(
+                    var relationalNullsNotInExpression = Expression.AndAlso(
                         Expression.Not(new InExpression(inExpression.Operand, inValuesNotNull)),
                         Expression.Not(new IsNullExpression(inExpression.Operand)));
 
-                    return Visit(nullSemanticsNotInExpression);
+                    return Visit(relationalNullsNotInExpression);
                 }
 
                 if (inValues.Count > 0)

--- a/src/EntityFramework.Relational/RelationalDatabaseFacadeExtensions.cs
+++ b/src/EntityFramework.Relational/RelationalDatabaseFacadeExtensions.cs
@@ -30,6 +30,9 @@ namespace Microsoft.Data.Entity
                         sql,
                         parameters);
 
+        public static void UseRelationalNulls([NotNull] this DatabaseFacade databaseFacade, bool useRelationalNulls)
+            => ((RelationalDatabase)databaseFacade.GetService<IDatabase>()).UseRelationalNulls = useRelationalNulls;
+
         public static DbConnection GetDbConnection([NotNull] this DatabaseFacade databaseFacade)
             => GetRelationalConnection(databaseFacade).DbConnection;
 

--- a/src/EntityFramework.Relational/RelationalQueryableExtensions.cs
+++ b/src/EntityFramework.Relational/RelationalQueryableExtensions.cs
@@ -23,15 +23,5 @@ namespace Microsoft.Data.Entity
             [NotNull] params object[] parameters)
             where TEntity : class
             => QueryableHelpers.CreateQuery(source, s => s.FromSql(sql, parameters));
-
-        internal static readonly MethodInfo UseRelationalNullSemanticsMethodInfo
-            = typeof(RelationalQueryableExtensions)
-                .GetTypeInfo().GetDeclaredMethod(nameof(UseRelationalNullSemantics));
-
-        [QueryAnnotationMethod]
-        public static IQueryable<TEntity> UseRelationalNullSemantics<TEntity>(
-            [NotNull] this IQueryable<TEntity> source)
-            where TEntity : class
-            => QueryableHelpers.CreateQuery(source, s => s.UseRelationalNullSemantics());
     }
 }

--- a/src/EntityFramework.Relational/Storage/RelationalDatabase.cs
+++ b/src/EntityFramework.Relational/Storage/RelationalDatabase.cs
@@ -39,6 +39,8 @@ namespace Microsoft.Data.Entity.Storage
             _options = options;
         }
 
+        public virtual bool UseRelationalNulls { get; set; }
+
         public override int SaveChanges(
             IReadOnlyList<InternalEntityEntry> entries)
             => _batchExecutor.Execute(

--- a/src/EntityFramework.Relational/Storage/RelationalDatabaseProviderServices.cs
+++ b/src/EntityFramework.Relational/Storage/RelationalDatabaseProviderServices.cs
@@ -25,6 +25,7 @@ namespace Microsoft.Data.Entity.Storage
 
         public override IDatabase Database => GetService<RelationalDatabase>();
         public override IModelValidator ModelValidator => GetService<RelationalModelValidator>();
+        public override ICompiledQueryCacheKeyGenerator CompiledQueryCacheKeyGenerator => GetService<RelationalCompiledQueryCacheKeyGenerator>();
         public override IValueGeneratorSelector ValueGeneratorSelector => GetService<RelationalValueGeneratorSelector>();
         public override IExpressionPrinter ExpressionPrinter => GetService<RelationalExpressionPrinter>();
         public override IResultOperatorHandler ResultOperatorHandler => GetService<RelationalResultOperatorHandler>();

--- a/src/EntityFramework.SqlServer/Query/SqlServerQueryCompilationContext.cs
+++ b/src/EntityFramework.SqlServer/Query/SqlServerQueryCompilationContext.cs
@@ -3,6 +3,7 @@
 
 using JetBrains.Annotations;
 using Microsoft.Data.Entity.Query.ExpressionVisitors;
+using Microsoft.Data.Entity.Storage;
 using Microsoft.Data.Entity.Utilities;
 using Microsoft.Framework.Logging;
 
@@ -14,12 +15,14 @@ namespace Microsoft.Data.Entity.Query
             [NotNull] ILoggerFactory loggerFactory,
             [NotNull] IEntityQueryModelVisitorFactory entityQueryModelVisitorFactory,
             [NotNull] IRequiresMaterializationExpressionVisitorFactory requiresMaterializationExpressionVisitorFactory,
+            [NotNull] IDatabase database,
             [NotNull] ILinqOperatorProvider linqOpeartorProvider,
             [NotNull] IQueryMethodProvider queryMethodProvider)
             : base(
                 Check.NotNull(loggerFactory, nameof(loggerFactory)),
                 Check.NotNull(entityQueryModelVisitorFactory, nameof(entityQueryModelVisitorFactory)),
                 Check.NotNull(requiresMaterializationExpressionVisitorFactory, nameof(requiresMaterializationExpressionVisitorFactory)),
+                Check.NotNull(database, nameof(database)),
                 Check.NotNull(linqOpeartorProvider, nameof(linqOpeartorProvider)),
                 Check.NotNull(queryMethodProvider, nameof(queryMethodProvider)))
         {

--- a/src/EntityFramework.SqlServer/Query/SqlServerQueryCompilationContextFactory.cs
+++ b/src/EntityFramework.SqlServer/Query/SqlServerQueryCompilationContextFactory.cs
@@ -3,6 +3,7 @@
 
 using JetBrains.Annotations;
 using Microsoft.Data.Entity.Query.ExpressionVisitors;
+using Microsoft.Data.Entity.Storage;
 using Microsoft.Data.Entity.Utilities;
 using Microsoft.Framework.Logging;
 
@@ -28,18 +29,20 @@ namespace Microsoft.Data.Entity.Query
             _requiresMaterializationExpressionVisitorFactory = requiresMaterializationExpressionVisitorFactory;
         }
 
-        public virtual QueryCompilationContext Create(bool async)
+        public virtual QueryCompilationContext Create(IDatabase database, bool async)
             => async
                 ? new SqlServerQueryCompilationContext(
                     _loggerFactory,
                     _entityQueryModelVisitorFactory,
                     _requiresMaterializationExpressionVisitorFactory,
+                    database,
                     new AsyncLinqOperatorProvider(),
                     new AsyncQueryMethodProvider())
                 : new SqlServerQueryCompilationContext(
                     _loggerFactory,
                     _entityQueryModelVisitorFactory,
                     _requiresMaterializationExpressionVisitorFactory,
+                    database,
                     new LinqOperatorProvider(),
                     new QueryMethodProvider());
     }

--- a/test/EntityFramework.Relational.FunctionalTests/AsyncFromSqlQueryTestBase.cs
+++ b/test/EntityFramework.Relational.FunctionalTests/AsyncFromSqlQueryTestBase.cs
@@ -330,8 +330,9 @@ FROM Customers")
         {
             using (var context = CreateContext())
             {
+                context.Database.UseRelationalNulls(true);
+
                 var actual = await context.Set<Customer>()
-                    .UseRelationalNullSemantics()
                     .FromSql("SELECT * FROM Customers")
                     .Where(c => c.ContactName == c.CompanyName)
                     .ToArrayAsync();

--- a/test/EntityFramework.Relational.FunctionalTests/FromSqlQueryTestBase.cs
+++ b/test/EntityFramework.Relational.FunctionalTests/FromSqlQueryTestBase.cs
@@ -364,8 +364,9 @@ FROM Customers")
         {
             using (var context = CreateContext())
             {
+                context.Database.UseRelationalNulls(true);
+
                 var actual = context.Set<Customer>()
-                    .UseRelationalNullSemantics()
                     .FromSql("SELECT * FROM Customers")
                     .Where(c => c.ContactName == c.CompanyName)
                     .ToArray();

--- a/test/EntityFramework.SqlServer.FunctionalTests/NullSemanticsQuerySqlServerTest.cs
+++ b/test/EntityFramework.SqlServer.FunctionalTests/NullSemanticsQuerySqlServerTest.cs
@@ -1016,6 +1016,21 @@ WHERE ([e].[NullableBoolA] <> [e].[NullableBoolB] OR @__prm_0 = 1)",
                 Sql);
         }
 
+        public override void Switching_null_semantics_produces_different_cache_entry()
+        {
+            base.Switching_null_semantics_produces_different_cache_entry();
+
+            Assert.Equal(
+                @"SELECT [e].[Id]
+FROM [NullSemanticsEntity1] AS [e]
+WHERE ([e].[NullableBoolA] = [e].[NullableBoolB] OR ([e].[NullableBoolA] IS NULL AND [e].[NullableBoolB] IS NULL))
+
+SELECT [e].[Id]
+FROM [NullSemanticsEntity1] AS [e]
+WHERE [e].[NullableBoolA] = [e].[NullableBoolB]",
+                Sql);
+        }
+
         private static string Sql
         {
             get { return TestSqlLoggerFactory.Sql; }


### PR DESCRIPTION
…evel

Removing necessity to setup null semantics on a per query basis - added a global switch:
context.Database.UseRelationalNulls(bool)

This also affects caching - we should produce different cache entries based on the value of UseDatabaseNullSemantics.
This can be used as a sample for other providers who want to introduce context-wide switches that affect the query.
CR: Andrew, Diego